### PR TITLE
include mount.bcachefs into deb if file exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ install: bcachefs lib
 	$(INSTALL) -m0755 -D initramfs/hook   $(DESTDIR)$(INITRAMFS_HOOK)
 	$(INSTALL) -m0755 -D mount.bcachefs.sh $(DESTDIR)$(ROOT_SBINDIR)
 	$(INSTALL) -m0755 -D libbcachefs.so -t $(DESTDIR)$(PREFIX)/lib/
-  
+	test -e mount.bcachefs && $(INSTALL) -m0755 -D mount.bcachefs $(DESTDIR)$(ROOT_SBINDIR)
 	sed -i '/^# Note: make install replaces/,$$d' $(DESTDIR)$(INITRAMFS_HOOK)
 	echo "copy_exec $(ROOT_SBINDIR)/bcachefs /sbin/bcachefs" >> $(DESTDIR)$(INITRAMFS_HOOK)
 


### PR DESCRIPTION
this line will add `mount.bcachefs` binary into `deb` package if `make deb` will be called after successful finishing of a `make mount.bcachefs`